### PR TITLE
chore: Add hardened .npmrc (7-day min-release-age) to fork HiromiShikata/eslint-plugin-googleappsscript (PR base = fork)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  npm-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+min-release-age=7
+ignore-scripts=true
+save-exact=true
+package-lock=true


### PR DESCRIPTION
Add a hardened `.npmrc` to protect against npm supply chain attacks (e.g., Mini Shai-Hulud npm worm).

## Changes

- Add `.npmrc` to repository root with the following settings:
  - `min-release-age=7` — blocks packages published less than 7 days ago from being installed (npm >= 11.10.0 supports this natively)
  - `ignore-scripts=true` — prevents execution of package lifecycle scripts during install
  - `save-exact=true` — pins exact versions to prevent unintended upgrades
  - `package-lock=true` — ensures a lockfile is always generated

## Verification

`npm install` completes successfully with this `.npmrc` present.

## Demo

https://github.com/user-attachments/assets/0b150253-558d-497e-b30b-e6df60f09759

- close https://github.com/HiromiShikata/umino-corporait-operation/issues/28791